### PR TITLE
Fixed Wrong InfoLabel from "video" -> "episode" & added Missing MediaType Definition

### DIFF
--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -58,6 +58,7 @@ def add_item(args, info, isFolder=True, total_items=0, mediatype="video"):
 
     if isFolder:
         # directory
+        infoLabels["mediatype"] = "tvshow"
         li.setInfo(mediatype, infoLabels)
     else:
         # playable video

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -61,7 +61,7 @@ def add_item(args, info, isFolder=True, total_items=0, mediatype="video"):
         li.setInfo(mediatype, infoLabels)
     else:
         # playable video
-        infoLabels["mediatype"] = "video"
+        infoLabels["mediatype"] = "tvshow"
         li.setInfo(mediatype, infoLabels)
         li.setProperty("IsPlayable", "true")
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -61,7 +61,7 @@ def add_item(args, info, isFolder=True, total_items=0, mediatype="video"):
         li.setInfo(mediatype, infoLabels)
     else:
         # playable video
-        infoLabels["mediatype"] = "tvshow"
+        infoLabels["mediatype"] = "episode"
         li.setInfo(mediatype, infoLabels)
         li.setProperty("IsPlayable", "true")
 


### PR DESCRIPTION
This fixes problem with grabbing info for queue items such as plot, release date, etc.
Only works for Queue Items so far working on other categories.