### PR TITLE
feat: :sparkles: options to enable/disable 'Next page' in episodes list

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -181,3 +181,7 @@ msgstr "Möchtest du das Video bei %s%% fortsetzen?"
 msgctxt "#30066"
 msgid "If the video does not start wait 30 seconds for the fallback to start."
 msgstr "Wenn das Video nicht abspielt, warte bitte 30 Sekunden, damit der Fallback einsetzen kann."
+
+msgctxt "#30067"
+msgid "Enable 'Next Page' in episode list."
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -181,3 +181,7 @@ msgstr ""
 msgctxt "#30066"
 msgid "If the video does not start wait 30 seconds for the fallback to start."
 msgstr ""
+
+msgctxt "#30067"
+msgid "Enable 'Next Page' in episode list."
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -176,3 +176,7 @@ msgstr "Voulez vous continuer à regarder depuis %s%% ?"
 msgctxt "#30066"
 msgid "If the video does not start wait 30 seconds for the fallback to start."
 msgstr "Si la vidéo ne démarre pas, attendez 30 secondes et recommencez."
+
+msgctxt "#30067"
+msgid "Enable 'Next Page' in episode list."
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -176,3 +176,7 @@ msgstr "Você quer continuar assistindo de %s%%?"
 msgctxt "#30066"
 msgid "If the video does not start wait 30 seconds for the fallback to start."
 msgstr "Se o vídeo não iniciar, aguarde 30 segundos e tente novamente."
+
+msgctxt "#30067"
+msgid "Enable 'Next Page' in episode list."
+msgstr "Ativar 'Próxima Página' na lista de episódios."

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -317,7 +317,7 @@ def viewEpisodes(args):
     """
     # api request
     payload = {"collection_id": args.collection_id,
-               "limit":         30,
+               "limit":         30 if args._nextpage else 9999,
                "offset":        int(getattr(args, "offset", 0)),
                "fields":        "media.name,media.media_id,media.collection_id,media.collection_name,media.description,media.episode_number,media.created,media.series_id, \
                                  media.screenshot_image,media.premium_only,media.premium_available,media.available,media.premium_available,media.duration,media.playhead"}
@@ -350,16 +350,17 @@ def viewEpisodes(args):
                        "mode":          "videoplay"},
                       isFolder=False)
 
-    # show next page button
-    if len(req["data"]) >= 30:
-        view.add_item(args,
-                      {"title":         args._addon.getLocalizedString(30044),
-                       "collection_id": args.collection_id,
-                       "offset":        int(getattr(args, "offset", 0)) + 30,
-                       "thumb":         args.thumb,
-                       "fanart":        args.fanart,
-                       "mode":          args.mode},
-                      isFolder=True)
+    if args._nextpage:
+        # show next page button
+        if len(req["data"]) >= 30:
+            view.add_item(args,
+                          {"title":         args._addon.getLocalizedString(30044),
+                           "collection_id": args.collection_id,
+                           "offset":        int(getattr(args, "offset", 0)) + 30,
+                           "thumb":         args.thumb,
+                           "fanart":        args.fanart,
+                           "mode":          args.mode},
+                          isFolder=True)
 
     view.endofdirectory(args)
     return True

--- a/resources/lib/crunchyroll.py
+++ b/resources/lib/crunchyroll.py
@@ -52,6 +52,8 @@ def main(argv):
         args._device_id = "".join(random.sample(char_set, 8)) + "-KODI-" + "".join(random.sample(char_set, 4)) + "-" + "".join(random.sample(char_set, 4)) + "-" + "".join(random.sample(char_set, 12))
         args._addon.setSetting("device_id", args._device_id)
 
+    # get next page episode settings
+    args._nextpage = args._addon.getSettingBool("episode_nextpage")
     # get subtitle language
     args._subtitle = args._addon.getSetting("subtitle_language")
     if args._subtitle == "0":

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,4 +9,5 @@
     <setting id="subtitle_language" type="select" lvalues="30021|30022|30023|30024|30025|30026|30027|30028|30029|30030|30031" label="30020" default="0" />
     <setting id="sync_playtime" type="bool" label="30003" default="true"/>
     <setting id="inputstream_adaptive" type="action" label="30004" option="close" action="RunPlugin(plugin://plugin.video.crunchyroll/?mode=hls)"/>
+    <setting id="episode_nextpage" type="bool" label="30067" default="false"/>
 </settings>


### PR DESCRIPTION
For me it's more practical to have the complete list with all the episodes, the payload of loading the partial list and having to load each next list whenever necessary is worse than loading only once.