### PR TITLE
Increase API timeout

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -42,6 +42,7 @@ class API:
     VERSON = "1.1.21.0"
     TOKEN  = "LNDJgOit5yaRIWN"
     DEVICE = "com.crunchyroll.windows.desktop"
+    TIMEOUT = 30
 
 
 def start(args):
@@ -153,7 +154,7 @@ def request(args, method, options, failed=False):
 
     # send payload
     url = API.URL + method + ".0.json"
-    response = urlopen(url, payload.encode("utf-8"))
+    response = urlopen(url, payload.encode("utf-8"), TIMEOUT)
 
     # parse response
     json_data = response.read().decode("utf-8")


### PR DESCRIPTION
As mentioned in https://github.com/MrKrabat/plugin.video.crunchyroll/issues/32 by simply increasing the timeout when doing API requests to Crunchyroll the addon can successfully load the user's Queue and no longer has loading errors.
This solved the issue for me and it will help people with slower internet have a smooth experience using the addon.