### PR TITLE
Use generic exception in destroy

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -134,7 +134,7 @@ def destroy(args):
     args._cj = False
     try:
         remove(getCookiePath(args))
-    except WindowsError:
+    except OSError:
         pass
 
 


### PR DESCRIPTION
When running on linux, the `destroy` function understandably throws a `NameError: global name 'WindowsError' is not defined`. `WindowsError` is a subclass of the generic `OSError` (as can be seen in the [hierarchy](https://docs.python.org/3.0/library/exceptions.html#exceptions.BytesWarning)), and will be merged into `OSError` with [Python 3.3](https://docs.python.org/3.3/library/exceptions.html#OSError). So to make it future-proof and also run without problems on other platforms, catch the generic exception instead.